### PR TITLE
fix: remove spurious console.log in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,11 +47,6 @@ function getSyntaxConfig(): SyntaxConfig {
 
 let syntaxConfig = getSyntaxConfig();
 
-console.log(
-    `syntaxConfig.keywords.map((t) => t.name):`,
-    syntaxConfig.keywords.map((t) => t.name)
-);
-
 let juliaStyleTags = styleTags({
     String: t.string,
     TripleString: t.string,


### PR DESCRIPTION
There is a spurious console.log in the index.ts file. This PR removes it.